### PR TITLE
fix: use cargo:rerun-if-changed instead of depgraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *~
 *.bk
+jni_tests/java/com/example/rust
+*.class
+*.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,13 @@ before_script:
       fi
 script:
   - cd macroslib
-  - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
+  - echo ${TRAVIS_RUST_VERSION}
+  - if [ "${TRAVIS_RUST_VERSION}" == "nightly" ]; then
+      echo "check code style";
       cargo fmt -- --write-mode diff;
+      cd ../jni_tests;
+      cargo fmt -- --write-mode diff;
+      cd ../macroslib;
     fi
   - cargo build -v
   - cargo test -v

--- a/jni_tests/Cargo.toml
+++ b/jni_tests/Cargo.toml
@@ -17,5 +17,4 @@ env_logger = "0.4.2"
 bindgen = "0.26.3"
 log = "0.3"
 rust_swig = { path = "../macroslib" }
-depgraph = "0.3.0"
 

--- a/jni_tests/java/com/example/Main.java
+++ b/jni_tests/java/com/example/Main.java
@@ -4,12 +4,12 @@ import java.util.Date;
 import java.util.Calendar;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import com.example.Foo;
-import com.example.Boo;
-import com.example.TestPathAndResult;
-import com.example.TestInner;
-import com.example.Xyz;
-import com.example.TestContainers;
+import com.example.rust.Foo;
+import com.example.rust.Boo;
+import com.example.rust.TestPathAndResult;
+import com.example.rust.TestInner;
+import com.example.rust.Xyz;
+import com.example.rust.TestContainers;
 
 class Main {
     private static void testDoubleOverload() {

--- a/jni_tests/run_tests.py
+++ b/jni_tests/run_tests.py
@@ -25,6 +25,14 @@ def find_dir(dir_name):
         last_dir = os.getcwd()
     raise Exception("Can not find %s" % dir_name)
 
+java_dir = str(os.path.join(os.getcwd(), "java/com/example"))
+purge(java_dir, ".*\.class$")
+java_native_dir = str(os.path.join(os.getcwd(), "java/com/example/rust"))
+if not os.path.exists(java_native_dir):
+    os.makedirs(java_native_dir)
+else:
+    purge(java_dir, ".*\.class$")
+
 subprocess.check_call(["cargo", "test"],
                       cwd = str(os.path.join(os.path.abspath('..'), "macroslib")),
                       shell=False)
@@ -35,13 +43,16 @@ subprocess.check_call(["cargo", "build"], shell=False)
 #becuase of http://bugs.python.org/issue17023
 use_shell = os.name == 'nt'
 
-java_dir = str(os.path.join(os.getcwd(), "src/com/example"))
-purge(java_dir, ".*\.class$")
-subprocess.check_call(["javac", "Main.java", "Foo.java", "Boo.java", "TestPathAndResult.java",
-                       "TestInner.java", "Xyz.java", "TestContainers.java", "OneStaticFunctionTest.java"],
+
+generated_java = [os.path.join("rust", f) for f in os.listdir(java_native_dir)
+                  if os.path.isfile(os.path.join(java_native_dir, f)) and f.endswith(".java")]
+javac_cmd_args = ["javac", "Main.java"]
+javac_cmd_args.extend(generated_java)
+    
+subprocess.check_call(javac_cmd_args,
                       cwd=java_dir, shell=use_shell)
 
-jar_dir = str(os.path.join(os.getcwd(), "src"))
+jar_dir = str(os.path.join(os.getcwd(), "java"))
 purge(java_dir, ".*\.jar$")
 subprocess.check_call(["jar", "cfv", "Test.jar", "com"], cwd=jar_dir, shell=use_shell)
 

--- a/jni_tests/src/lib.rs.in
+++ b/jni_tests/src/lib.rs.in
@@ -239,11 +239,11 @@ foreigner_class!(class TestPathAndResult {
 
 #[allow(non_snake_case)]
 #[no_mangle]
-pub fn Java_com_example_TestPathAndResult_do_1testHandArrayReturn(env: *mut JNIEnv,
+pub fn Java_com_example_rust_TestPathAndResult_do_1testHandArrayReturn(env: *mut JNIEnv,
                                                                   _: jclass,
                                                                   _: jlong)
                                                                   -> jobjectArray {
-    let class_id = ::std::ffi::CString::new("com/example/Boo").unwrap();
+    let class_id = ::std::ffi::CString::new("com/example/rust/Boo").unwrap();
     let jcls: jclass = unsafe { (**env).FindClass.unwrap()(env, class_id.as_ptr()) };
     if jcls.is_null() {
         panic!("Can not find class_id {:?}", class_id);
@@ -292,8 +292,8 @@ foreigner_class!(class TestInner {
 
 #[allow(non_snake_case)]
 #[no_mangle]
-pub fn Java_com_example_TestInner_getInner(env: *mut JNIEnv, _: jclass) -> jobject {
-    let class_id = ::std::ffi::CString::new("com/example/TestInner$Inner").unwrap();
+pub fn Java_com_example_rust_TestInner_getInner(env: *mut JNIEnv, _: jclass) -> jobject {
+    let class_id = ::std::ffi::CString::new("com/example/rust/TestInner$Inner").unwrap();
     let jcls: jclass = unsafe { (**env).FindClass.unwrap()(env, class_id.as_ptr()) };
     assert!(!jcls.is_null());
     let ret: jobject = unsafe { (**env).AllocObject.unwrap()(env, jcls) };


### PR DESCRIPTION
In case of usage of depgraph it does not rebuild,
if one of build.dependencies changed
comment#14