### PR TITLE
c++feature: make possible to return from value from callback

### DIFF
--- a/c++_tests/c++/main.cpp
+++ b/c++_tests/c++/main.cpp
@@ -81,6 +81,14 @@ static void c_simple_cb_without_args(void *opaque)
     ++c_simple_cb_counter_without_args;
 }
 
+static char c_simple_cb_is_odd(int32_t x, void *opaque)
+{
+    assert(opaque != nullptr);
+    const int tag = *static_cast<int *>(opaque);
+    EXPECT_EQ(17, tag);
+    return (x % 2) == 1;
+}
+
 TEST(c_Foo, Simple)
 {
     auto foo = Foo_new(1, "a");
@@ -97,6 +105,7 @@ TEST(c_Foo, Simple)
         c_delete_int,
         c_simple_cb,
         c_simple_cb_without_args,
+        c_simple_cb_is_odd,
     };
     c_simple_cb_counter = 0;
     c_simple_cb_counter_without_args = 0;
@@ -123,6 +132,7 @@ TEST(Foo, Simple)
         c_delete_int,
         c_simple_cb,
         c_simple_cb_without_args,
+        c_simple_cb_is_odd,
     };
     c_simple_cb_counter = 0;
     c_simple_cb_counter_without_args = 0;
@@ -168,6 +178,10 @@ struct MySomeObserver final : public SomeObserver {
     {
         std::cout << "onStateChangedWithoutArgs\n";
         ++f2_call;
+    }
+    bool isOdd(int32_t num) override
+    {
+        return num % 2 == 1;
     }
 };
 

--- a/c++_tests/src/cpp_glue.rs.in
+++ b/c++_tests/src/cpp_glue.rs.in
@@ -31,6 +31,8 @@ impl Foo {
         //println!("call_me begin");
         cb.on_state_changed(2, false);
         cb.on_state_changed_without_args();
+        assert!(cb.is_odd(1));
+        assert!(!cb.is_odd(2));
     }
     fn one_and_half(&self) -> f64 {
         (self.data as f64) * 1.5
@@ -52,12 +54,14 @@ fn f_hypot(a: f64, b: f64) -> f64 {
 trait SomeObserver {
     fn on_state_changed(&self, _: i32, _: bool);
     fn on_state_changed_without_args(&self);
+    fn is_odd(&self, x: i32) -> bool;
 }
 
 foreign_interface!(interface SomeObserver {
     self_type SomeObserver;
     onStateChanged = SomeObserver::on_state_changed(&self, _: i32, _: bool);
     onStateChangedWithoutArgs = SomeObserver::on_state_changed_without_args(&self);
+    isOdd = SomeObserver::is_odd(&self, x: i32) -> bool;
 });
 
 foreigner_class!(class Foo {
@@ -656,4 +660,9 @@ foreigner_class!(class TestPassInterface {
     self_type TestPassInterface;
     constructor TestPassInterface::default() -> TestPassInterface;
     static_method TestPassInterface::use_interface(a: Box<Box<Interface>>, b: i32) -> i32;
+});
+
+foreign_interface!(interface ToString {
+    self_type ::std::string::ToString;
+    toString = ::std::string::ToString::to_string(&self) -> String;
 });


### PR DESCRIPTION
Implemented for returning bool from callbacks,
but it also handle now (as mentioned in #112):

foreign_interface!(interface ToString {
    self_type std::string::ToString;
    toString = std::string::ToString::to_string(&self) -> String;
});

but not practicle yet,
it generate:

virtual const char * toString() = 0,
so it possible to return only strings with static storage