### PR TITLE
Allow circular dependencies between classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,10 @@
 jni_tests/java/com/example/rust
 *.class
 *.jar
-c++_tests/c++/rust_interface
+/c++_tests/c++/rust_interface
+/c++_tests/c++/build
+/c++_tests/c++/build_with_boost
+target/
+/macroslib/target/
+.vscode
+Cargo.lock

--- a/macroslib/src/cpp/rust_str.h
+++ b/macroslib/src/cpp/rust_str.h
@@ -16,7 +16,9 @@ struct RustStrView {
     bool empty() const noexcept { return this->len == 0; }
     std::string to_std_string() const { return std::string{ data, len }; }
 #endif
-#if __cplusplus > 201402L
+#if (defined(__clang__) && __clang_major__ >= 4) \
+    || (defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 7) \
+    || (defined(_MSC_VER) && _MSC_VER >= 1910)
     std::string_view to_string_view() const { return std::string_view{ data, len }; }
 #endif
 #ifdef BOOST_STRING_VIEW_HPP
@@ -76,7 +78,9 @@ public:
     std::string to_std_string() const { return std::string(data, len); }
     size_t size() const noexcept { return this->len; }
     bool empty() const noexcept { return this->len == 0; }
-#if __cplusplus > 201402L
+#if (defined(__clang__) && __clang_major__ >= 4) \
+    || (defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 7) \
+    || (defined(_MSC_VER) && _MSC_VER >= 1910)
     std::string_view to_string_view() const { return std::string_view(data, len); }
 #endif
 

--- a/macroslib/src/java_jni/mod.rs
+++ b/macroslib/src/java_jni/mod.rs
@@ -100,6 +100,10 @@ impl LanguageGenerator for JavaConfig {
         if let Some(this_type_for_method) = class.this_type_for_method.as_ref() {
             let this_type: RustType = this_type_for_method.clone().into();
             let this_type = this_type.implements("SwigForeignClass");
+            debug!(
+                "register_class: add implements SwigForeignClass for {}",
+                this_type.normalized_name
+            );
             let jobject_name = "jobject";
             let jobject_ty = parse_type! { jobject };
             let my_jobj_ti = RustType::new(
@@ -113,6 +117,73 @@ impl LanguageGenerator for JavaConfig {
                     name: class.name.to_string().into(),
                 },
             );
+
+            if let Some(constructor_ret_type) =
+                class.constructor_ret_type.as_ref() {
+                conv_map.add_type(this_type.clone());
+
+                let constructor_ret_type: RustType = constructor_ret_type.clone().into();
+                conv_map.add_type(constructor_ret_type);
+
+                let (this_type_for_method, _code_box_this) =
+                    TypeMap::convert_to_heap_pointer(&this_type, "this");
+
+                let jlong_ti: RustType = parse_type! { jlong }.into();
+                let this_type_for_method_ty = &this_type_for_method.ty;
+                //handle foreigner_class as input arg
+                conv_map.add_conversation_rule(
+                    jlong_ti.clone(),
+                    parse_type! { & #this_type_for_method_ty }.into(),
+                    format!(
+                        r#"
+        let {to_var}: &{this_type} = unsafe {{
+            jlong_to_pointer::<{this_type}>({from_var}).as_mut().unwrap()
+        }};
+    "#,
+                        to_var = TO_VAR_TEMPLATE,
+                        from_var = FROM_VAR_TEMPLATE,
+                        this_type = this_type_for_method.normalized_name,
+                    )
+                    .into(),
+                );
+
+                //handle foreigner_class as input arg
+                conv_map.add_conversation_rule(
+                    jlong_ti.clone(),
+                    parse_type! { &mut #this_type_for_method_ty }.into(),
+                    format!(
+                        r#"
+        let {to_var}: &mut {this_type} = unsafe {{
+            jlong_to_pointer::<{this_type}>({from_var}).as_mut().unwrap()
+        }};
+    "#,
+                        to_var = TO_VAR_TEMPLATE,
+                        from_var = FROM_VAR_TEMPLATE,
+                        this_type = this_type_for_method.normalized_name,
+                    )
+                    .into(),
+                );
+
+                let unpack_code =
+                    TypeMap::unpack_from_heap_pointer(&this_type_for_method, TO_VAR_TEMPLATE, true);
+                conv_map.add_conversation_rule(
+                    jlong_ti,
+                    this_type,
+                    format!(
+                        r#"
+        let {to_var}: *mut {this_type} = unsafe {{
+            jlong_to_pointer::<{this_type}>({from_var}).as_mut().unwrap()
+        }};
+    {unpack_code}
+    "#,
+                        to_var = TO_VAR_TEMPLATE,
+                        from_var = FROM_VAR_TEMPLATE,
+                        this_type = this_type_for_method.normalized_name,
+                        unpack_code = unpack_code,
+                    )
+                    .into(),
+                );
+            }
         }
         Ok(())
     }

--- a/macroslib/src/java_jni/mod.rs
+++ b/macroslib/src/java_jni/mod.rs
@@ -89,16 +89,11 @@ impl ForeignMethodSignature for JniForeignMethodSignature {
 }
 
 impl LanguageGenerator for JavaConfig {
-    fn generate(
+    fn register_class(
         &self,
         conv_map: &mut TypeMap,
-        _: usize,
-        class: &ForeignerClassInfo,
-    ) -> Result<Vec<TokenStream>> {
-        debug!(
-            "generate: begin for {}, this_type_for_method {:?}",
-            class.name, class.this_type_for_method
-        );
+        class: &ForeignerClassInfo
+    ) -> Result<()> {
         class
             .validate_class()
             .map_err(|err| DiagnosticError::new(class.span(), &err))?;
@@ -119,6 +114,19 @@ impl LanguageGenerator for JavaConfig {
                 },
             );
         }
+        Ok(())
+    }
+
+    fn generate(
+        &self,
+        conv_map: &mut TypeMap,
+        _: usize,
+        class: &ForeignerClassInfo,
+    ) -> Result<Vec<TokenStream>> {
+        debug!(
+            "generate: begin for {}, this_type_for_method {:?}",
+            class.name, class.this_type_for_method
+        );
 
         let f_methods_sign = find_suitable_foreign_types_for_methods(conv_map, class)?;
         java_code::generate_java_code(

--- a/macroslib/tests/expectations/circular_deps.cpp
+++ b/macroslib/tests/expectations/circular_deps.cpp
@@ -1,0 +1,2 @@
+"static void a(const B & a_0)";
+"static void b(const A & a_0)";

--- a/macroslib/tests/expectations/circular_deps.java
+++ b/macroslib/tests/expectations/circular_deps.java
@@ -1,2 +1,2 @@
-"public static final void a(B a_0)";
-"public static final void b(A a_0)";
+"public static void a(@NonNull B a0)";
+"public static void b(@NonNull A a0)";

--- a/macroslib/tests/expectations/circular_deps.java
+++ b/macroslib/tests/expectations/circular_deps.java
@@ -1,0 +1,2 @@
+"public static final void a(B a_0)";
+"public static final void b(A a_0)";

--- a/macroslib/tests/expectations/circular_deps.rs
+++ b/macroslib/tests/expectations/circular_deps.rs
@@ -1,0 +1,11 @@
+foreigner_class!(class A {
+    self_type A;
+    constructor A::default() -> A;
+    static_method A::a(b: &B);
+});
+
+foreigner_class!(class B {
+    self_type B;
+    constructor B::default() -> B;
+    static_method B::b(a: &A);
+});

--- a/macroslib/tests/test_expectations.rs
+++ b/macroslib/tests/test_expectations.rs
@@ -87,7 +87,7 @@ fn test_expectations_main() {
         }
     }
 
-    assert_eq!(40, ntests);
+    assert_eq!(41, ntests);
 }
 
 #[test]


### PR DESCRIPTION
Allow code like this:

```rust
struct A {}
impl A {
    fn a(b: &B){}
}

struct B {}
impl B {
    fn b(a: &A){}
}
```