### PR TITLE
rustdoc to javadoc comments

### DIFF
--- a/jni_tests/src/lib.rs.in
+++ b/jni_tests/src/lib.rs.in
@@ -52,8 +52,18 @@ fn chrono_now() -> DateTime<Utc> {
     Utc::now()
 }
 
-foreigner_class!(class Foo {
+foreigner_class!(
+/// Class comment description for Foo.
+class Foo {
     self_type Foo;
+    /// some text about the new function
+    ///
+    /// ```
+    /// some markdown example in the text
+    /// ```
+    ///
+    /// @param a0 id - somenumber
+    /// @param a1 desc - more information
     constructor Foo::new(_: i32, _: &str) -> Foo;
     method Foo::f(&self, _: i32, _: i32) -> i32;  alias calcF;
     method Foo::f_double(&self, _: f64, _: f64) -> f64;

--- a/macroslib/src/java_jni/java_code.rs
+++ b/macroslib/src/java_jni/java_code.rs
@@ -454,16 +454,50 @@ fn convert_code_for_method(f_method: &JniForeignMethodSignature) -> String {
 }
 
 fn doc_comments_to_java_comments(doc_comments: &[String], class_comments: bool) -> String {
+    if class_comments {
+        javadoc_class_comment(doc_comments)
+    } else {
+        javadoc_comment(doc_comments)
+    }
+}
+
+fn javadoc_class_comment(class_comments: &[String]) -> String {
+    use std::fmt::Write;
+    let mut comments = String::new();
+    for (i, comment) in class_comments.iter().enumerate() {
+        if i != 0 {
+            comments.push('\n');
+        }
+        if i == 0 {
+            comments.push_str("/**\n");
+        }
+
+        write!(&mut comments, " * {}", comment.trim()).unwrap();
+
+        if i == class_comments.len() - 1 {
+            comments.push_str("\n */");
+        }
+    }
+    comments
+}
+
+fn javadoc_comment(doc_comments: &[String]) -> String {
     use std::fmt::Write;
     let mut comments = String::new();
     for (i, comment) in doc_comments.iter().enumerate() {
         if i != 0 {
             comments.push('\n');
         }
-        if !class_comments {
-            comments.push_str("    ");
+        comments.push_str("    ");
+        if i == 0 {
+            comments.push_str("/**\n    ");
         }
-        write!(&mut comments, "//{}", comment.trim()).unwrap();
+
+        write!(&mut comments, " * {}", comment.trim()).unwrap();
+
+        if i == doc_comments.len() - 1 {
+            comments.push_str("\n     */");
+        }
     }
     comments
 }


### PR DESCRIPTION
since the target use case seems to be libraries, semantically mapping
rustdoc comments to javadoc comments seems to make the most sense.